### PR TITLE
Fix issues that break builds using the paystack-android library on AGP >= 3.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.6.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Oct 26 19:40:34 WAT 2017
+#Thu Mar 05 12:34:35 WAT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/pinpad/src/main/res/values/attrs_foreground_view.xml
+++ b/pinpad/src/main/res/values/attrs_foreground_view.xml
@@ -17,9 +17,9 @@
 <resources>
 
     <declare-styleable name="ForegroundView">
-        <attr name="foreground" />
-        <attr name="foregroundInsidePadding" />
-        <attr name="foregroundGravity" />
+        <attr name="foreground" format="reference" />
+        <attr name="foregroundInsidePadding" format="dimension" />
+        <attr name="foregroundGravity" format="integer" />
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
### Changes made by this pull request
- Updates Android Gradle Plugin to `3.6.0`
- Fixes issue where attributes for `ForegroundRelativeLayout` were not found. This has broken builds for developers using version `3.6` of the Android Gradle Plugin(AGP).

**Related issue**
- https://github.com/PaystackHQ/paystack-android/issues/83