### PR TITLE
Fix attribute format for `foregroundInsidePadding`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You do not need to clone this repository or download the files. Just add the fol
 
 ```gradle
 dependencies {
-  compile 'co.paystack.android.design.widget:pinpad:1.0.1'
+  compile 'co.paystack.android.design.widget:pinpad:1.0.4'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0'
+        classpath 'com.android.tools.build:gradle:3.6.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
 
@@ -27,12 +27,12 @@ task clean(type: Delete) {
 }
 
 ext {
-    compileSdkVersion = 27
+    compileSdkVersion = 29
     minSdkVersion = 14
-    targetSdkVersion = 27
-    versionCode = 2
-    versionName = "1.0.1"
+    targetSdkVersion = 29
+    versionCode = 3
+    versionName = "1.0.4"
 
-    buildToolsVersion = "27.0.0"
-    supportLibraryVersion = '27.0.0'
+    buildToolsVersion = "29.0.2"
+    supportLibraryVersion = '28.0.0'
 }

--- a/pinpad/src/main/res/values/attrs_foreground_view.xml
+++ b/pinpad/src/main/res/values/attrs_foreground_view.xml
@@ -18,7 +18,7 @@
 
     <declare-styleable name="ForegroundView">
         <attr name="foreground" format="reference" />
-        <attr name="foregroundInsidePadding" format="dimension" />
+        <attr name="foregroundInsidePadding" format="boolean" />
         <attr name="foregroundGravity" format="integer" />
     </declare-styleable>
 


### PR DESCRIPTION
- Fix attribute format for `foregroundInsidePadding` that caused build errors in apps using dependent libraries.
- Update ReadMe.md to reflect version 1.0.4